### PR TITLE
Fix for LocalRepositoryResolver exception on Windows

### DIFF
--- a/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/m2/LocalRepositoryResolver.java
+++ b/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/m2/LocalRepositoryResolver.java
@@ -16,7 +16,7 @@ public class LocalRepositoryResolver extends RepositoryResolver {
     public File resolve(String gav) throws IOException {
 
         Path m2repo = findM2Repo();
-        Path artifactPath = m2repo.resolve(gavToPath(gav, File.separator));
+        Path artifactPath = m2repo.resolve(gavToPath(gav, "/"));
 
         if ( Files.notExists( artifactPath ) ) {
             return null;


### PR DESCRIPTION
Making LocalRepositoryResolver use gsvToPath() the same way that JarRepositoryResolver uses it allows the server to work on my Windows box again
