### PR TITLE
Fix for NullPointerException when no username/password specified

### DIFF
--- a/fractions/datasources/src/main/java/org/wildfly/swarm/datasources/DatasourceDeployment.java
+++ b/fractions/datasources/src/main/java/org/wildfly/swarm/datasources/DatasourceDeployment.java
@@ -55,16 +55,18 @@ public class DatasourceDeployment implements Deployment {
             XmlWriter.Element security = datasource.element("security");
 
             String username = this.ds.getUserName();
-            username = username == null ? "" : username;
-            security.element("user-name")
-                    .content(username)
-                    .end();
+            if (username != null) {
+                security.element("user-name")
+                        .content(username)
+                        .end();
+            }
 
             String password = this.ds.getPassword();
-            password = password == null ? "" : password;
-            security.element("password")
-                    .content(password)
-                    .end();
+            if (password != null) {
+                security.element("password")
+                        .content(password)
+                        .end();
+            }
 
             security.end();
             datasource.end();

--- a/fractions/datasources/src/main/java/org/wildfly/swarm/datasources/DatasourceDeployment.java
+++ b/fractions/datasources/src/main/java/org/wildfly/swarm/datasources/DatasourceDeployment.java
@@ -54,12 +54,16 @@ public class DatasourceDeployment implements Deployment {
 
             XmlWriter.Element security = datasource.element("security");
 
+            String username = this.ds.getUserName();
+            username = username == null ? "" : username;
             security.element("user-name")
-                    .content(this.ds.getUserName())
+                    .content(username)
                     .end();
 
+            String password = this.ds.getPassword();
+            password = password == null ? "" : password;
             security.element("password")
-                    .content(this.ds.getPassword())
+                    .content(password)
                     .end();
 
             security.end();

--- a/fractions/transactions/pom.xml
+++ b/fractions/transactions/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ JBoss, Home of Professional Open Source.
-  ~ Copyright 2013, Red Hat, Inc., and individual contributors
+  ~ Copyright 2015, Red Hat, Inc., and individual contributors
   ~ as indicated by the @author tags. See the copyright.txt file in the
   ~ distribution for a full listing of individual contributors.
   ~
@@ -74,21 +74,10 @@
           <artifactId>wildfly-controller</artifactId>
           <scope>provided</scope>
         </dependency>
-
-<!--
         <dependency>
-            <groupId>org.wildfly.core</groupId>
-            <artifactId>wildfly-core-feature-pack</artifactId>
-            <type>zip</type>
-            <scope>provided</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
+          <groupId>org.jboss.spec.javax.transaction</groupId>
+          <artifactId>jboss-transaction-api_1.2_spec</artifactId>
         </dependency>
--->
     </dependencies>
 
 </project>


### PR DESCRIPTION
In my main method, I use the following line to construct my datasource:
`Datasource ds = new Datasource("MyDatabase").connectionURL("jdbc:sqlserver://hostname;databaseName=MyDatabase;integratedSecurity=true;").driver("sqlserver");`
- I don't need a username and password because `integratedSecurity=true`, so I don't specify it. 
- Not specifying it throws a NullPointerException when that XML is generated
- Things work fine if I let it write blank tags like `<username></username><password></password>`
