### PR TITLE
Add support for undertow websockets and concurrency utils and fix for InvalidPathException on Windows

### DIFF
--- a/api/container/src/main/java/org/wildfly/swarm/container/DefaultWarDeployment.java
+++ b/api/container/src/main/java/org/wildfly/swarm/container/DefaultWarDeployment.java
@@ -17,8 +17,13 @@ import java.nio.file.attribute.BasicFileAttributes;
 
 /**
  * @author Bob McWhirter
+ * @author Ken Finnigan
  */
 public class DefaultWarDeployment extends WarDeployment {
+
+    public DefaultWarDeployment(Container container) throws IOException, ModuleLoadException {
+        this(container.getShrinkWrapDomain().getArchiveFactory().create(WebArchive.class));
+    }
 
     public DefaultWarDeployment(WebArchive archive) throws IOException, ModuleLoadException {
         super( archive );

--- a/api/datasources/pom.xml
+++ b/api/datasources/pom.xml
@@ -49,15 +49,6 @@
             <plugin>
                 <groupId>org.wildfly.swarm</groupId>
                 <artifactId>wildfly-swarm-fraction-plugin</artifactId>
-<!--
-                <configuration>
-                  <feature-pack>org.wildfly:wildfly-feature-pack</feature-pack>
-                  <modules>
-                    <module>org.jboss.as.connector</module>
-                    <module>org.jboss.vfs</module>
-                  </modules>
-                </configuration>
--->
             </plugin>
         </plugins>
     </build>
@@ -75,12 +66,14 @@
           <groupId>org.wildfly.swarm</groupId>
           <artifactId>wildfly-swarm-jca</artifactId>
         </dependency>
-<!--
         <dependency>
-            <groupId>org.jboss</groupId>
-            <artifactId>jboss-vfs</artifactId>
+            <groupId>org.wildfly.swarm</groupId>
+            <artifactId>wildfly-swarm-logging</artifactId>
         </dependency>
--->
+        <dependency>
+            <groupId>org.wildfly.swarm</groupId>
+            <artifactId>wildfly-swarm-naming</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/api/ee/pom.xml
+++ b/api/ee/pom.xml
@@ -55,6 +55,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.jboss.spec.javax.enterprise.concurrent</groupId>
+            <artifactId>jboss-concurrency-api_1.0_spec</artifactId>
+        </dependency>
+        <dependency>
           <groupId>org.wildfly.swarm</groupId>
           <artifactId>wildfly-swarm-container</artifactId>
         </dependency>

--- a/api/ee/src/main/resources/provided-dependencies.txt
+++ b/api/ee/src/main/resources/provided-dependencies.txt
@@ -1,0 +1,1 @@
+org.jboss.spec.javax.enterprise.concurrent:jboss-concurrency-api_1.0_spec

--- a/api/jaxrs/src/main/java/org/wildfly/swarm/jaxrs/JAXRSDeployment.java
+++ b/api/jaxrs/src/main/java/org/wildfly/swarm/jaxrs/JAXRSDeployment.java
@@ -61,9 +61,9 @@ public class JAXRSDeployment extends WarDeployment {
 
     protected void ensureApplication() {
         if (!this.hasApplication) {
-            //setApplication(DefaultApplication.class);
             String name = "org.wildfly.swarm.generated.WildFlySwarmDefaultJAXRSApplication";
             this.archive.add( new ByteArrayAsset( ApplicationFactory.create( name, "/" )), "WEB-INF/classes/" + name.replace('.', '/' ) + ".class");
+            this.hasApplication = true;
         }
     }
 

--- a/api/jpa/pom.xml
+++ b/api/jpa/pom.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2015, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.wildfly.swarm</groupId>
+        <artifactId>wildfly-swarm-api</artifactId>
+        <version>1.0.0.Alpha2-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+
+    <groupId>org.wildfly.swarm</groupId>
+    <artifactId>wildfly-swarm-jpa</artifactId>
+
+    <name>WildFly Swarm: JPA API</name>
+    <description>WildFly Swarm: JPA API</description>
+
+    <packaging>jar</packaging>
+
+    <build>
+        <resources>
+          <resource>
+            <directory>src/main/resources</directory>
+            <filtering>true</filtering>
+          </resource>
+        </resources>
+        <plugins>
+            <plugin>
+                <groupId>org.wildfly.swarm</groupId>
+                <artifactId>wildfly-swarm-fraction-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.hibernate.javax.persistence</groupId>
+            <artifactId>hibernate-jpa-2.1-api</artifactId>
+        </dependency>
+
+        <dependency>
+          <groupId>org.wildfly.swarm</groupId>
+          <artifactId>wildfly-swarm-container</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.swarm</groupId>
+            <artifactId>wildfly-swarm-datasources</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.wildfly</groupId>
+            <artifactId>wildfly-feature-pack</artifactId>
+            <type>zip</type>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/api/jpa/pom.xml
+++ b/api/jpa/pom.xml
@@ -67,6 +67,14 @@
             <groupId>org.wildfly.swarm</groupId>
             <artifactId>wildfly-swarm-datasources</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wildfly.swarm</groupId>
+            <artifactId>wildfly-swarm-logging</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.swarm</groupId>
+            <artifactId>wildfly-swarm-naming</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.wildfly</groupId>

--- a/api/jpa/src/main/java/org/wildfly/swarm/jpa/JPAFraction.java
+++ b/api/jpa/src/main/java/org/wildfly/swarm/jpa/JPAFraction.java
@@ -1,0 +1,11 @@
+package org.wildfly.swarm.jpa;
+
+import org.wildfly.swarm.container.Fraction;
+
+/**
+ * @author Ken Finnigan
+ */
+public class JPAFraction implements Fraction {
+    public JPAFraction() {
+    }
+}

--- a/api/jpa/src/main/java/org/wildfly/swarm/jpa/JPARuntimeModuleProvider.java
+++ b/api/jpa/src/main/java/org/wildfly/swarm/jpa/JPARuntimeModuleProvider.java
@@ -1,0 +1,13 @@
+package org.wildfly.swarm.jpa;
+
+import org.wildfly.swarm.container.RuntimeModuleProvider;
+
+/**
+ * @author Ken Finnigan
+ */
+public class JPARuntimeModuleProvider implements RuntimeModuleProvider {
+    @Override
+    public String getModuleName() {
+        return "org.wildfly.swarm.runtime.jpa";
+    }
+}

--- a/api/jpa/src/main/resources/META-INF/services/org.wildfly.swarm.container.RuntimeModuleProvider
+++ b/api/jpa/src/main/resources/META-INF/services/org.wildfly.swarm.container.RuntimeModuleProvider
@@ -1,0 +1,1 @@
+org.wildfly.swarm.jpa.JPARuntimeModuleProvider

--- a/api/jpa/src/main/resources/modules/org/wildfly/swarm/jpa/main/module.xml
+++ b/api/jpa/src/main/resources/modules/org/wildfly/swarm/jpa/main/module.xml
@@ -1,0 +1,21 @@
+<module xmlns="urn:jboss:module:1.3" name="org.wildfly.swarm.jpa">
+
+    <dependencies>
+      <!-- For when run with bonafide IDE classpath -->
+      <system export="true">
+        <paths>
+          <path name="org/wildfly/swarm/jpa"/>
+        </paths>
+      </system>
+
+      <!-- For when bootstrapped through a fat-jar -->
+      <module name="org.wildfly.swarm.bootstrap" optional="true" export="true">
+        <exports>
+          <include path="org/wildfly/swarm/jpa"/>
+        </exports>
+      </module>
+
+      <module name="org.wildfly.swarm.runtime.jpa"/>
+
+    </dependencies>
+</module>

--- a/api/jpa/src/main/resources/modules/org/wildfly/swarm/runtime/jpa/main/module.xml
+++ b/api/jpa/src/main/resources/modules/org/wildfly/swarm/runtime/jpa/main/module.xml
@@ -1,0 +1,13 @@
+<module xmlns="urn:jboss:module:1.3" name="org.wildfly.swarm.runtime.jpa">
+    <resources>
+        <artifact name="org.wildfly.swarm:wildfly-swarm-runtime-jpa:${project.version}"/>
+    </resources>
+
+    <dependencies>
+      <module name="org.wildfly.swarm.jpa"/>
+      <module name="org.wildfly.swarm.container"/>
+      <module name="org.wildfly.swarm.runtime.container"/>
+
+      <module name="org.jboss.as.jpa"/>
+    </dependencies>
+</module>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -47,6 +47,7 @@
       <module>io</module>
       <module>jca</module>
       <module>jaxrs</module>
+      <module>jpa</module>
       <module>logging</module>
       <module>messaging</module>
       <module>msc</module>

--- a/api/undertow/pom.xml
+++ b/api/undertow/pom.xml
@@ -103,7 +103,10 @@
           <groupId>org.jboss.spec.javax.servlet</groupId>
           <artifactId>jboss-servlet-api_3.1_spec</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>org.jboss.spec.javax.websocket</groupId>
+            <artifactId>jboss-websocket-api_1.1_spec</artifactId>
+        </dependency>
 
 
         <dependency>

--- a/api/undertow/src/main/resources/provided-dependencies.txt
+++ b/api/undertow/src/main/resources/provided-dependencies.txt
@@ -1,1 +1,2 @@
 org.jboss.spec.javax.servlet:jboss-servlet-api_3.1_spec
+org.jboss.spec.javax.websocket:jboss-websocket-api_1.1_spec

--- a/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/util/Layout.java
+++ b/bootstrap/src/main/java/org/wildfly/swarm/bootstrap/util/Layout.java
@@ -4,11 +4,14 @@ import org.jboss.modules.Module;
 import org.jboss.modules.ModuleIdentifier;
 import org.jboss.modules.ModuleLoadException;
 
+import java.io.File;
 import java.io.FileFilter;
 import java.io.FileInputStream;
 import java.io.IOError;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -50,8 +53,15 @@ public class Layout {
     public static Path getRoot() throws IOException {
         URL location = Layout.class.getProtectionDomain().getCodeSource().getLocation();
         if ( location.getProtocol().equals( "file" ) ) {
-            Path path = Paths.get(location.getPath());
-            return path;
+            try {
+                URI locationURI = location.toURI();
+                Path locationPath = Paths.get(locationURI);
+                File locationFile = locationPath.toFile();
+                String locationFilePathString = locationFile.getPath();
+                return Paths.get(locationFilePathString);
+            } catch (URISyntaxException e) {
+                throw new RuntimeException(e);
+            }
         }
 
         throw new IOException("Unable to determine root" );

--- a/plugin/src/main/java/org/wildfly/swarm/plugin/PackageMojo.java
+++ b/plugin/src/main/java/org/wildfly/swarm/plugin/PackageMojo.java
@@ -110,9 +110,7 @@ public class PackageMojo extends AbstractMojo { //extends AbstractSwarmMojo {
     private void setupDirectory() throws MojoFailureException {
         this.dir = Paths.get(this.projectBuildDir, "wildfly-swarm-archive");
         try {
-            if (Files.notExists(dir)) {
-                Files.createDirectories(dir);
-            } else {
+            if (Files.exists(dir)) {
                 emptyDir(dir);
             }
         } catch (IOException e) {
@@ -446,7 +444,7 @@ public class PackageMojo extends AbstractMojo { //extends AbstractSwarmMojo {
         this.project.addAttachedArtifact(artifact);
     }
 
-    private void emptyDir(Path dir) throws IOException {
+    private void emptyDir(final Path dir) throws IOException {
         Files.walkFileTree(dir, new SimpleFileVisitor<Path>() {
             @Override
             public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
@@ -482,6 +480,7 @@ public class PackageMojo extends AbstractMojo { //extends AbstractSwarmMojo {
                     Files.createDirectories(fsEach);
                 } else {
                     try (InputStream in = jarFile.getInputStream(each)) {
+                        Files.createDirectories(fsEach.getParent());
                         Files.copy(in, fsEach, StandardCopyOption.REPLACE_EXISTING);
                     }
                 }
@@ -539,10 +538,5 @@ public class PackageMojo extends AbstractMojo { //extends AbstractSwarmMojo {
 
         return repos;
     }
-
-
-    /*
-
-    */
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -140,6 +140,11 @@
             </dependency>
             <dependency>
                 <groupId>org.wildfly.swarm</groupId>
+                <artifactId>wildfly-swarm-jpa</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wildfly.swarm</groupId>
                 <artifactId>wildfly-swarm-logging</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/runtime/jpa/pom.xml
+++ b/runtime/jpa/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ JBoss, Home of Professional Open Source.
-  ~ Copyright 2013, Red Hat, Inc., and individual contributors
+  ~ Copyright 2015, Red Hat, Inc., and individual contributors
   ~ as indicated by the @author tags. See the copyright.txt file in the
   ~ distribution for a full listing of individual contributors.
   ~
@@ -25,41 +25,38 @@
 
     <parent>
         <groupId>org.wildfly.swarm</groupId>
-        <artifactId>wildfly-swarm-parent</artifactId>
+        <artifactId>wildfly-swarm-runtime</artifactId>
         <version>1.0.0.Alpha2-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
 
     <groupId>org.wildfly.swarm</groupId>
-    <artifactId>wildfly-swarm-runtime</artifactId>
+    <artifactId>wildfly-swarm-runtime-jpa</artifactId>
 
-    <name>WildFly Swarm: Runtime Parent</name>
-    <description>WildFly Swarm: Runtime Parent</description>
+    <name>WildFly Swarm: JPA Runtime</name>
+    <description>WildFly Swarm: JPA Runtime</description>
 
-    <packaging>pom</packaging>
+    <packaging>jar</packaging>
 
-    <modules>
-      <module>bean-validation</module>
-      <module>connector</module>
-      <module>container</module>
-      <module>datasources</module>
-      <module>ee</module>
-      <module>io</module>
-      <module>jca</module>
-      <module>jaxrs</module>
-      <module>jpa</module>
-      <module>logging</module>
-      <module>messaging</module>
-      <module>msc</module>
-      <module>naming</module>
-<!--
-      <module>request-controller</module>
--->
-      <module>security</module>
-      <module>transactions</module>
-      <module>undertow</module>
-      <module>weld</module>
-      <module>weld-jaxrs</module>
-    </modules>
+    <dependencies>
+        <dependency>
+          <groupId>org.wildfly.swarm</groupId>
+          <artifactId>wildfly-swarm-runtime-container</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>org.wildfly.swarm</groupId>
+          <artifactId>wildfly-swarm-jpa</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>org.jboss</groupId>
+          <artifactId>jboss-dmr</artifactId>
+          <scope>provided</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.wildfly.core</groupId>
+          <artifactId>wildfly-controller</artifactId>
+          <scope>provided</scope>
+        </dependency>
+    </dependencies>
 
 </project>

--- a/runtime/jpa/src/main/java/org/wildfly/swarm/runtime/jpa/JPAConfiguration.java
+++ b/runtime/jpa/src/main/java/org/wildfly/swarm/runtime/jpa/JPAConfiguration.java
@@ -1,0 +1,52 @@
+package org.wildfly.swarm.runtime.jpa;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.dmr.ModelNode;
+import org.wildfly.swarm.jpa.JPAFraction;
+import org.wildfly.swarm.runtime.container.AbstractServerConfiguration;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.EXTENSION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+
+/**
+ * @author Ken Finnigan
+ */
+public class JPAConfiguration extends AbstractServerConfiguration<JPAFraction> {
+
+    public JPAConfiguration() {
+        super(JPAFraction.class);
+    }
+
+    @Override
+    public JPAFraction defaultFraction() {
+        return new JPAFraction();
+    }
+
+    @Override
+    public List<ModelNode> getList(JPAFraction fraction) {
+        List<ModelNode> list = new ArrayList<>();
+
+        PathAddress address = PathAddress.pathAddress(PathElement.pathElement(SUBSYSTEM, "jpa"));
+
+        ModelNode node = new ModelNode();
+        node.get(OP_ADDR).set(EXTENSION, "org.jboss.as.jpa");
+        node.get(OP).set(ADD);
+        list.add(node);
+
+        node = new ModelNode();
+        node.get(OP_ADDR).set(address.toModelNode());
+        node.get(OP).set(ADD);
+        node.get("default-datasource").set("");
+        node.get("default-extended-persistence-inheritence").set("DEEP");
+        list.add(node);
+
+        return list;
+    }
+}

--- a/runtime/jpa/src/main/resources/META-INF/services/org.wildfly.swarm.runtime.container.ServerConfiguration
+++ b/runtime/jpa/src/main/resources/META-INF/services/org.wildfly.swarm.runtime.container.ServerConfiguration
@@ -1,0 +1,1 @@
+org.wildfly.swarm.runtime.jpa.JPAConfiguration


### PR DESCRIPTION
On Windows, that `location.getPath` returns with an extra slash at the front of the path string, causing `Paths.get()` to throw the exception: 

<pre>
Exception in thread "main" java.nio.file.InvalidPathException: Illegal char <:> at index 2: /C:/Users/amann.malik/IdeaProjects/demo-warming-service/target/demo-warming-service-1.0-SNAPSHOT-swarm.jar
    at sun.nio.fs.WindowsPathParser.normalize(WindowsPathParser.java:182)
    at sun.nio.fs.WindowsPathParser.parse(WindowsPathParser.java:153)
    at sun.nio.fs.WindowsPathParser.parse(WindowsPathParser.java:77)
    at sun.nio.fs.WindowsPath.parse(WindowsPath.java:94)
    at sun.nio.fs.WindowsFileSystem.getPath(WindowsFileSystem.java:255)
    at java.nio.file.Paths.get(Paths.java:84)
    at org.wildfly.swarm.bootstrap.util.Layout.getRoot(Layout.java:53)
    at org.wildfly.swarm.bootstrap.util.Layout.isFatJar(Layout.java:29)
    at org.wildfly.swarm.bootstrap.modules.BootstrapModuleFinder.findModule(BootstrapModuleFinder.java:36)
    at org.jboss.modules.ModuleLoader.findModule(ModuleLoader.java:452)
    at org.jboss.modules.ModuleLoader.loadModuleLocal(ModuleLoader.java:355)
    at org.jboss.modules.ModuleLoader.preloadModule(ModuleLoader.java:302)
    at org.jboss.modules.ModuleLoader.loadModule(ModuleLoader.java:234)
    at org.wildfly.swarm.bootstrap.Main.main(Main.java:37)

Process finished with exit code 1
</pre>
