### PR TITLE
Provide JSR-236 concurrency utilities API through wildfly-swarm-ee

### DIFF
--- a/api/ee/pom.xml
+++ b/api/ee/pom.xml
@@ -42,6 +42,12 @@
       <groupId>org.wildfly.swarm</groupId>
       <artifactId>wildfly-swarm-container</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.jboss.spec.javax.enterprise.concurrent</groupId>
+      <artifactId>jboss-concurrency-api_1.0_spec</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>org.wildfly.core</groupId>
       <artifactId>wildfly-core-feature-pack</artifactId>

--- a/api/ee/src/main/resources/provided-dependencies.txt
+++ b/api/ee/src/main/resources/provided-dependencies.txt
@@ -1,0 +1,1 @@
+org.jboss.spec.javax.enterprise.concurrent:jboss-concurrency-api_1.0_spec


### PR DESCRIPTION
These changes enable use of the `javax.enterprise.concurrent` utilities for end users declaring a dependency on `wildfly-swarm-ee`, fixing #65
