### PR TITLE
Fix jboss-msc and jboss-javax-sql-api references

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,8 +39,8 @@
     <version.wildfly.swarm.fraction.plugin>1.0.0.Alpha3</version.wildfly.swarm.fraction.plugin>
 
     <version.wildfly>9.0.0.CR2</version.wildfly>
-    <version.org.jboss.msc.jboss-msc>1.2.4.Final</version.org.jboss.msc.jboss-msc>
-    <version.org.jboss.spec.javax.sql.jboss-javax-sql-api_7.0_spec>1.0.0.Final</version.org.jboss.spec.javax.sql.jboss-javax-sql-api_7.0_spec>
+    <version.org.jboss.msc.jboss-msc>1.2.6.Final</version.org.jboss.msc.jboss-msc>
+    <version.org.jboss.spec.javax.sql.jboss-javax-sql-api_7.0_spec>1.0.1.Final</version.org.jboss.spec.javax.sql.jboss-javax-sql-api_7.0_spec>
 
     <maven.min.version>3.2.1</maven.min.version>
 


### PR DESCRIPTION
pom.xml now refers to the proper versions of above modules
related to Wildfly 9.0.0.CR2.

Test were not passing and I was getting this error below when trying to run the generated jar.

Exception in thread "main" org.jboss.modules.ModuleLoadException: Error loading
module from modules/org/jboss/msc/main/module.xml
        at org.jboss.modules.ModuleXmlParser.parseModuleXml(ModuleXmlParser.java
:150)
        at org.jboss.modules.ModuleXmlParserBridge.parseModuleXml(ModuleXmlParse
rBridge.java:17)
        at org.wildfly.swarm.bootstrap.modules.BootstrapClasspathModuleFinder.fi
ndModule(BootstrapClasspathModuleFinder.java:35)
        at org.jboss.modules.ModuleLoader.findModule(ModuleLoader.java:452)
        at org.jboss.modules.ModuleLoader.loadModuleLocal(ModuleLoader.java:355)

```
    at org.jboss.modules.ModuleLoader.preloadModule(ModuleLoader.java:302)
    at org.jboss.modules.Module.addPaths(Module.java:1028)
    at org.jboss.modules.Module.link(Module.java:1398)
    at org.jboss.modules.Module.relinkIfNecessary(Module.java:1426)
    at org.jboss.modules.ModuleLoader.loadModule(ModuleLoader.java:238)
    at org.wildfly.swarm.bootstrap.Main.main(Main.java:37)
```

Caused by: org.jboss.modules.xml.XmlPullParserException: Failed to resolve artif
act 'org.jboss.msc:jboss-msc:1.2.4.Final' (position: END_TAG seen ...s>\r\n
   <artifact name="org.jboss.msc:jboss-msc:1.2.4.Final"/>... @34:63)
        at org.jboss.modules.ModuleXmlParser.parseArtifact(ModuleXmlParser.java:
756)
        at org.jboss.modules.ModuleXmlParser.parseResources(ModuleXmlParser.java
:650)
        at org.jboss.modules.ModuleXmlParser.parseModuleContents(ModuleXmlParser
.java:446)
        at org.jboss.modules.ModuleXmlParser.parseDocument(ModuleXmlParser.java:
261)
        at org.jboss.modules.ModuleXmlParser.parseModuleXml(ModuleXmlParser.java
:148)
        ... 10 more
