### PR TITLE
Fix mainClass closing tag in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ the desired `Main-Class` inside your `.war.
         <configuration>
           <archive>
             <manifest>
-              <mainClass>com.mycompany.myapp.MyMain</addClasspath>
+              <mainClass>com.mycompany.myapp.MyMain</mainClass>
             </manifest>
           </archive>
         </configuration>


### PR DESCRIPTION
Small typo correction. Just got caught out by this by my lazy copy / pasting from the README.
