### PR TITLE
Provide access to the main(String[] args) at the Container and msc service levels.

### DIFF
--- a/api/container/src/main/java/org/wildfly/swarm/container/Container.java
+++ b/api/container/src/main/java/org/wildfly/swarm/container/Container.java
@@ -43,6 +43,8 @@ public class Container {
     private Server server;
     private Deployer deployer;
     private Domain domain;
+    /** Command line args if any */
+    private String[] args;
 
     /**
      * Construct a new, un-started container.
@@ -221,7 +223,7 @@ public class Container {
             }
         }
 
-        list.add( binding );
+        list.add(binding);
     }
 
     /**
@@ -283,6 +285,23 @@ public class Container {
     public Container deploy(Archive deployment) throws Exception {
         this.deployer.deploy(deployment);
         return this;
+    }
+
+    /**
+     * Get the possibly null container main method arguments.
+     * @return main method arguments, possibly null
+     */
+    public String[] getArgs() {
+        return args;
+    }
+
+    /**
+     * Set the main method arguments. This will be available as a ValueService<String[]> under the name
+     * wildfly.swarm.main-args
+     * @param args arguments passed to the main(String[]) method.
+     */
+    public void setArgs(String[] args) {
+        this.args = args;
     }
 
     /**

--- a/runtime/container/src/main/java/org/wildfly/swarm/runtime/container/RuntimeServer.java
+++ b/runtime/container/src/main/java/org/wildfly/swarm/runtime/container/RuntimeServer.java
@@ -84,6 +84,9 @@ public class RuntimeServer implements Server {
             public void activate(ServiceActivatorContext context) throws ServiceRegistryException {
                 context.getServiceTarget().addService(ServiceName.of("wildfly", "swarm", "temp-provider"), new ValueService<>(new ImmediateValue<Object>(tempFileProvider)))
                         .install();
+                // Provide the main command line args as a value service
+                context.getServiceTarget().addService(ServiceName.of("wildfly", "swarm", "main-args"), new ValueService<>(new ImmediateValue<Object>(config.getArgs())))
+                    .install();
             }
         });
 


### PR DESCRIPTION
I wanted to access the command line args passed into the swarm main(String[]) method inside my service activator, so this change looked like the simplest way to accomplish that. I have an update to the wildfly-swarm-example-msc example as well.
