### PR TITLE
switch to new Undertow predicate syntax

### DIFF
--- a/api/undertow/src/main/java/org/wildfly/swarm/undertow/UndertowHandlersAsset.java
+++ b/api/undertow/src/main/java/org/wildfly/swarm/undertow/UndertowHandlersAsset.java
@@ -23,7 +23,7 @@ public class UndertowHandlersAsset implements Asset {
 
         StringBuilder conf = new StringBuilder();
         for ( String[] each : this.staticContent ) {
-            conf.append( "path-prefix['" + each[0] + "'] -> static-content[base='" + each[1] + "']\n");
+            conf.append( "path-prefix('" + each[0] + "') -> static-content(base='" + each[1] + "')\n");
         }
 
         return new ByteArrayInputStream( conf.toString().getBytes() );


### PR DESCRIPTION
This removes the following warnings (2) from showing up in the log during startup

```
WARN: UT005060: Predicate path-prefix['/'] -> static-content[base='public']
 uses old style square braces to define predicates, which will be removed in a future release. predicate[value] should be changed to predicate(value)
```
