### PR TITLE
Add a new messaging-clustered module (#111)

### DIFF
--- a/container/runtime/src/main/java/org/wildfly/swarm/container/runtime/RuntimeServer.java
+++ b/container/runtime/src/main/java/org/wildfly/swarm/container/runtime/RuntimeServer.java
@@ -276,8 +276,14 @@ public class RuntimeServer implements Server {
             ServiceLoader<ServerConfiguration> configLoaders = module.loadService(ServerConfiguration.class);
 
             for (ServerConfiguration serverConfig : configLoaders) {
-                this.configByFractionType.put(serverConfig.getType(), serverConfig);
-                this.configList.add(serverConfig);
+                ServerConfiguration oldConfig = this.configByFractionType.get(serverConfig.getType());
+                if (oldConfig == null || serverConfig.priority() > oldConfig.priority()) {
+                    this.configByFractionType.put(serverConfig.getType(), serverConfig);
+                    this.configList.add(serverConfig);
+                    if (oldConfig != null) {
+                        this.configList.remove(oldConfig);
+                    }
+                }
             }
         }
     }

--- a/container/runtime/src/main/java/org/wildfly/swarm/container/runtime/ServerConfiguration.java
+++ b/container/runtime/src/main/java/org/wildfly/swarm/container/runtime/ServerConfiguration.java
@@ -37,4 +37,15 @@ public interface ServerConfiguration<T extends Fraction> {
         return false;
     }
 
+    /**
+     * Priority is useful when two ServerConfigurations handle the same
+     * Fraction type T. The ServerConfiguration with the highest priority
+     * will win and the others will not get used.
+     *
+     * @return 0, the default priority
+     */
+    default int priority() {
+        return 0;
+    }
+
 }

--- a/messaging-clustered/api/pom.xml
+++ b/messaging-clustered/api/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2015 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.wildfly.swarm</groupId>
+    <artifactId>wildfly-swarm-messaging-clustered-parent</artifactId>
+    <version>1.0.0.Alpha5-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+
+  <groupId>org.wildfly.swarm</groupId>
+  <artifactId>wildfly-swarm-messaging-clustered</artifactId>
+
+  <name>WildFly Swarm: Messaging Clustered API</name>
+  <description>WildFly Swarm: Messaging Clustered API</description>
+
+  <packaging>jar</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>wildfly-swarm-clustering</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>wildfly-swarm-messaging</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>wildfly-swarm-messaging-clustered-modules</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>wildfly-swarm-undertow</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/messaging-clustered/api/src/main/java/org/wildfly/swarm/messaging/clustered/MessagingClusteredRuntimeModuleProvider.java
+++ b/messaging-clustered/api/src/main/java/org/wildfly/swarm/messaging/clustered/MessagingClusteredRuntimeModuleProvider.java
@@ -1,0 +1,15 @@
+package org.wildfly.swarm.messaging.clustered;
+
+import org.wildfly.swarm.container.RuntimeModuleProvider;
+
+public class MessagingClusteredRuntimeModuleProvider implements RuntimeModuleProvider {
+    @Override
+    public String getModuleName() {
+        return "org.wildfly.swarm.messaging.clustered";
+    }
+
+    @Override
+    public String getSlotName() {
+        return "runtime";
+    }
+}

--- a/messaging-clustered/api/src/main/resources/META-INF/services/org.wildfly.swarm.container.RuntimeModuleProvider
+++ b/messaging-clustered/api/src/main/resources/META-INF/services/org.wildfly.swarm.container.RuntimeModuleProvider
@@ -1,0 +1,1 @@
+org.wildfly.swarm.messaging.clustered.MessagingClusteredRuntimeModuleProvider

--- a/messaging-clustered/modules/pom.xml
+++ b/messaging-clustered/modules/pom.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2015 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.wildfly.swarm</groupId>
+    <artifactId>wildfly-swarm-messaging-clustered-parent</artifactId>
+    <version>1.0.0.Alpha5-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+
+  <groupId>org.wildfly.swarm</groupId>
+  <artifactId>wildfly-swarm-messaging-clustered-modules</artifactId>
+
+  <name>WildFly Swarm: Messaging Clustered Modules</name>
+  <description>WildFly Swarm: Messaging Clustered Modules</description>
+
+  <packaging>jar</packaging>
+
+  <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
+    <plugins>
+      <plugin>
+        <groupId>org.wildfly.swarm</groupId>
+        <artifactId>wildfly-swarm-fraction-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>wildfly-swarm-bootstrap</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>wildfly-swarm-messaging-modules</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.core</groupId>
+      <artifactId>wildfly-core-feature-pack</artifactId>
+      <type>zip</type>
+      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly</groupId>
+      <artifactId>wildfly-servlet-feature-pack</artifactId>
+      <type>zip</type>
+      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly</groupId>
+      <artifactId>wildfly-feature-pack</artifactId>
+      <type>zip</type>
+      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/messaging-clustered/modules/src/main/resources/modules/org/wildfly/swarm/messaging/clustered/api/module.xml
+++ b/messaging-clustered/modules/src/main/resources/modules/org/wildfly/swarm/messaging/clustered/api/module.xml
@@ -1,0 +1,10 @@
+<module xmlns="urn:jboss:module:1.3" name="org.wildfly.swarm.messaging.clustered" slot="api">
+  <resources>
+    <artifact name="org.wildfly.swarm:wildfly-swarm-messaging-clustered:${project.version}"/>
+  </resources>
+
+  <dependencies>
+    <module name="org.wildfly.swarm.messaging" slot="api"/>
+    <module name="org.wildfly.swarm.container"/>
+  </dependencies>
+</module>

--- a/messaging-clustered/modules/src/main/resources/modules/org/wildfly/swarm/messaging/clustered/main/module.xml
+++ b/messaging-clustered/modules/src/main/resources/modules/org/wildfly/swarm/messaging/clustered/main/module.xml
@@ -1,0 +1,15 @@
+<module xmlns="urn:jboss:module:1.3" name="org.wildfly.swarm.messaging.clustered">
+
+  <dependencies>
+    <!-- For when run with bonafide IDE classpath -->
+    <system export="true">
+      <paths>
+        <path name="org/wildfly/swarm/messaging/clustered"/>
+      </paths>
+    </system>
+
+    <!-- For when bootstrapped through a fat-jar -->
+    <module name="org.wildfly.swarm.messaging.clustered" slot="api" export="true" services="export"/>
+
+  </dependencies>
+</module>

--- a/messaging-clustered/modules/src/main/resources/modules/org/wildfly/swarm/messaging/clustered/runtime/module.xml
+++ b/messaging-clustered/modules/src/main/resources/modules/org/wildfly/swarm/messaging/clustered/runtime/module.xml
@@ -1,0 +1,18 @@
+<module xmlns="urn:jboss:module:1.3" name="org.wildfly.swarm.messaging.clustered" slot="runtime">
+  <resources>
+    <artifact name="org.wildfly.swarm:wildfly-swarm-messaging-clustered-runtime:${project.version}"/>
+  </resources>
+
+  <dependencies>
+    <module name="org.wildfly.swarm.messaging.clustered"/>
+    <module name="org.wildfly.swarm.messaging" slot="runtime"/>
+    <module name="org.wildfly.swarm.container"/>
+    <module name="org.wildfly.swarm.container" slot="runtime"/>
+    <module name="org.jboss.shrinkwrap"/>
+    
+    <!-- only required if http-acceptor is used -->
+    <module name="io.undertow.core"/>
+    <module name="org.jboss.xnio"/>
+    <module name="org.jboss.xnio.netty.netty-xnio-transport"/>
+  </dependencies>
+</module>

--- a/messaging-clustered/modules/src/main/resources/wildfly-swarm-bootstrap.conf
+++ b/messaging-clustered/modules/src/main/resources/wildfly-swarm-bootstrap.conf
@@ -1,0 +1,1 @@
+org.wildfly.swarm.messaging.clustered

--- a/messaging-clustered/pom.xml
+++ b/messaging-clustered/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2015 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.wildfly.swarm</groupId>
+    <artifactId>wildfly-swarm-parent</artifactId>
+    <version>1.0.0.Alpha5-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+
+  <groupId>org.wildfly.swarm</groupId>
+  <artifactId>wildfly-swarm-messaging-clustered-parent</artifactId>
+
+  <name>WildFly Swarm: Messaging Clustered</name>
+  <description>WildFly Swarm: Messaging Clustered</description>
+
+  <packaging>pom</packaging>
+
+  <modules>
+    <module>api</module>
+    <module>runtime</module>
+    <module>modules</module>
+    <module>test</module>
+  </modules>
+
+</project>

--- a/messaging-clustered/runtime/pom.xml
+++ b/messaging-clustered/runtime/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2015 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.wildfly.swarm</groupId>
+    <artifactId>wildfly-swarm-messaging-clustered-parent</artifactId>
+    <version>1.0.0.Alpha5-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+
+  <groupId>org.wildfly.swarm</groupId>
+  <artifactId>wildfly-swarm-messaging-clustered-runtime</artifactId>
+
+  <name>WildFly Swarm: Messaging Clustered Runtime</name>
+  <description>WildFly Swarm: Messaging Clustered Runtime</description>
+
+  <packaging>jar</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>wildfly-swarm-messaging-clustered</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>wildfly-swarm-messaging-runtime</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/messaging-clustered/runtime/src/main/java/org/wildfly/swarm/messaging/clustered/runtime/MessagingClusteredConfiguration.java
+++ b/messaging-clustered/runtime/src/main/java/org/wildfly/swarm/messaging/clustered/runtime/MessagingClusteredConfiguration.java
@@ -1,0 +1,81 @@
+package org.wildfly.swarm.messaging.clustered.runtime;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.dmr.ModelNode;
+import org.wildfly.swarm.messaging.MessagingServer;
+import org.wildfly.swarm.messaging.runtime.MessagingConfiguration;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.*;
+
+public class MessagingClusteredConfiguration extends MessagingConfiguration {
+
+    @Override
+    public int priority() {
+        return 1;
+    }
+
+    @Override
+    protected void addServer(MessagingServer server, List<ModelNode> list) {
+        super.addServer(server, list);
+
+        PathAddress serverAddress = this.address.append("server", server.name());
+
+        // TODO: lots of hardcoded assumptions here
+
+        ModelNode node = new ModelNode();
+        node.get(OP_ADDR).set(serverAddress.toModelNode());
+        node.get(OP).set(WRITE_ATTRIBUTE_OPERATION);
+        node.get("name").set("cluster-password");
+        node.get("value").set("CHANGE ME !!");
+        list.add(node);
+
+        node = new ModelNode();
+        node.get(OP_ADDR).set(serverAddress.append("http-connector", "http-connector").toModelNode());
+        node.get(OP).set(ADD);
+        node.get(SOCKET_BINDING).set("http");
+        node.get("params").get("http-upgrade-endpoint").set("http-acceptor");
+        list.add(node);
+
+        node = new ModelNode();
+        node.get(OP_ADDR).set(serverAddress.append("http-acceptor", "http-acceptor").toModelNode());
+        node.get(OP).set(ADD);
+        node.get("http-listener").set("default");
+        list.add(node);
+
+        node = new ModelNode();
+        node.get(OP_ADDR).set(serverAddress.append("broadcast-group", "bg-group1").toModelNode());
+        node.get(OP).set(ADD);
+        node.get("connectors").setEmptyList().add("http-connector");
+        node.get("jgroups-stack").set("udp");
+        node.get("jgroups-channel").set("activemq-cluster");
+        list.add(node);
+
+        node = new ModelNode();
+        node.get(OP_ADDR).set(serverAddress.append("discovery-group", "dg-group1").toModelNode());
+        node.get(OP).set(ADD);
+        node.get("jgroups-stack").set("udp");
+        node.get("jgroups-channel").set("activemq-cluster");
+        list.add(node);
+
+        node = new ModelNode();
+        node.get(OP_ADDR).set(serverAddress.append("cluster-connection", "my-cluster").toModelNode());
+        node.get(OP).set(ADD);
+        node.get("cluster-connection-address").set("jms");
+        node.get("connector-name").set("http-connector");
+        node.get("discovery-group").set("dg-group1");
+        list.add(node);
+
+        node = new ModelNode();
+        node.get(OP_ADDR).set(serverAddress.append("connection-factory", "RemoteConnectionFactory").toModelNode());
+        node.get(OP).set(ADD);
+        node.get("ha").set(true);
+        node.get("block-on-acknowledge").set(true);
+        node.get("reconnect-attempts").set(-1);
+        node.get("connectors").setEmptyList().add("http-connector");
+        node.get("entries").setEmptyList().add("java:jboss/exported/jms/RemoteConnectionFactory");
+        list.add(node);
+    }
+}

--- a/messaging-clustered/runtime/src/main/resources/META-INF/services/org.wildfly.swarm.container.runtime.ServerConfiguration
+++ b/messaging-clustered/runtime/src/main/resources/META-INF/services/org.wildfly.swarm.container.runtime.ServerConfiguration
@@ -1,0 +1,1 @@
+org.wildfly.swarm.messaging.clustered.runtime.MessagingClusteredConfiguration

--- a/messaging-clustered/test/pom.xml
+++ b/messaging-clustered/test/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2015 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.wildfly.swarm</groupId>
+    <artifactId>wildfly-swarm-messaging-clustered-parent</artifactId>
+    <version>1.0.0.Alpha5-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+
+  <groupId>org.wildfly.swarm</groupId>
+  <artifactId>wildfly-swarm-messaging-clustered-test</artifactId>
+
+  <name>WildFly Swarm: Messaging Clustered Test</name>
+  <description>WildFly Swarm: Messaging Clustered Test</description>
+
+  <packaging>jar</packaging>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-install-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>wildfly-swarm-messaging-clustered</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>wildfly-swarm-messaging-clustered-modules</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.swarm</groupId>
+      <artifactId>wildfly-swarm-arquillian</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.arquillian.junit</groupId>
+      <artifactId>arquillian-junit-container</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/messaging-clustered/test/src/test/java/org/wildfly/swarm/messaging/clustered/MessagingClusteredArquillianTest.java
+++ b/messaging-clustered/test/src/test/java/org/wildfly/swarm/messaging/clustered/MessagingClusteredArquillianTest.java
@@ -1,0 +1,33 @@
+package org.wildfly.swarm.messaging.clustered;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.junit.Test;
+import org.wildfly.swarm.ContainerFactory;
+import org.wildfly.swarm.container.Container;
+import org.wildfly.swarm.container.JARArchive;
+import org.wildfly.swarm.messaging.MessagingFraction;
+
+public class MessagingClusteredArquillianTest implements ContainerFactory {
+
+    @Deployment(testable = false)
+    public static Archive createDeployment() {
+        JARArchive deployment = ShrinkWrap.create(JARArchive.class);
+        deployment.add(EmptyAsset.INSTANCE, "nothing");
+        return deployment;
+    }
+
+    @Override
+    public Container newContainer(String... args) throws Exception {
+        return new Container().fraction( new MessagingFraction() );
+    }
+
+    @Test
+    @RunAsClient
+    public void testNothing() {
+
+    }
+}

--- a/messaging-clustered/test/src/test/java/org/wildfly/swarm/messaging/clustered/MessagingClusteredTest.java
+++ b/messaging-clustered/test/src/test/java/org/wildfly/swarm/messaging/clustered/MessagingClusteredTest.java
@@ -1,0 +1,16 @@
+package org.wildfly.swarm.messaging.clustered;
+
+import org.junit.Test;
+import org.wildfly.swarm.container.Container;
+import org.wildfly.swarm.messaging.MessagingFraction;
+import org.wildfly.swarm.messaging.MessagingServer;
+
+public class MessagingClusteredTest {
+
+    @Test
+    public void testSimple() throws Exception {
+        Container container = new Container();
+        container.fraction(new MessagingFraction().server(new MessagingServer()));
+        container.start().stop();
+    }
+}

--- a/messaging/runtime/src/main/java/org/wildfly/swarm/messaging/runtime/MessagingConfiguration.java
+++ b/messaging/runtime/src/main/java/org/wildfly/swarm/messaging/runtime/MessagingConfiguration.java
@@ -23,7 +23,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUB
  */
 public class MessagingConfiguration extends AbstractServerConfiguration<MessagingFraction> {
 
-    private PathAddress address = PathAddress.pathAddress(PathElement.pathElement(SUBSYSTEM, "messaging-activemq"));
+    protected PathAddress address = PathAddress.pathAddress(PathElement.pathElement(SUBSYSTEM, "messaging-activemq"));
 
     public MessagingConfiguration() {
         super(MessagingFraction.class);

--- a/pom.xml
+++ b/pom.xml
@@ -382,6 +382,7 @@
     <module>logstash</module>
     <module>mail</module>
     <module>messaging</module>
+    <module>messaging-clustered</module>
     <module>msc</module>
     <module>naming</module>
     <module>remoting</module>


### PR DESCRIPTION
This is a first pass at getting basic messaging clustering
working. Right now lots of things are hardcoded, including the cluster
password, so it's not yet suitable for production usage. Once we get
the config-api working with messaging then all these values can be
configured.

To enable clustering, just use wildfly-swarm-messaging-clustered as
a dependency instead of wildfly-swarm-messaging.

As part of this change, I've added a priority with a default value of
0 to ServerConfiguration. This priority is used when more than one
ServerConfiguration implementation have the same Fraction type T. The
ServerConfiguration with the higher priority is the only one that gets
used.
