### PR TITLE
Throw container StartExceptions instead of logging them and moving on

### DIFF
--- a/container/runtime/src/main/java/org/wildfly/swarm/container/runtime/RuntimeServer.java
+++ b/container/runtime/src/main/java/org/wildfly/swarm/container/runtime/RuntimeServer.java
@@ -30,6 +30,7 @@ import org.jboss.modules.ModuleLoadException;
 import org.jboss.msc.service.ServiceActivator;
 import org.jboss.msc.service.ServiceActivatorContext;
 import org.jboss.msc.service.ServiceContainer;
+import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceRegistryException;
 import org.jboss.msc.service.ValueService;
@@ -147,6 +148,12 @@ public class RuntimeServer implements Server {
 
 
         this.serviceContainer = this.container.start(list, this.contentProvider, activators);
+        for (ServiceName serviceName : this.serviceContainer.getServiceNames()) {
+            ServiceController<?> serviceController = this.serviceContainer.getService(serviceName);
+            if (serviceController.getStartException() != null) {
+                throw serviceController.getStartException();
+            }
+        }
         ModelController controller = (ModelController) this.serviceContainer.getService(Services.JBOSS_SERVER_CONTROLLER).getValue();
         Executor executor = Executors.newSingleThreadExecutor();
 


### PR DESCRIPTION
This change makes it so that any exceptions that come from WildFly
during container start get thrown by RuntimeServer#start instead of
just being logged by WildFly. This is especially useful in testing
scenarios where tests do `container.start().stop()` since that kind of
test can't otherwise detect various kinds of errors upon startup.

We may want this to just be enabled with some special testing flag, or
maybe we'd always like to throw the exception on start since Swarm is
used in more embedded scenarios. It's up for debate, so discuss before
merging.
