### PR TITLE
Remove duplicated prerequisits maven version setting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,10 +87,6 @@
     <maven.compiler.source>1.8</maven.compiler.source>
   </properties>
 
-  <prerequisites>
-    <maven>3.1.0</maven>
-  </prerequisites>
-
   <build>
     <plugins>
       <plugin>


### PR DESCRIPTION
Since it already exists maven-enforcer-plugin setting(`<maven.min.version>3.2.1</maven.min.version>`), it's not necessary and confusing.
