### PR TITLE
<soap:address> URL rewrite to jboss.bind.address

### DIFF
--- a/webservices/api/src/main/java/org/wildfly/swarm/webservices/WebServicesFraction.java
+++ b/webservices/api/src/main/java/org/wildfly/swarm/webservices/WebServicesFraction.java
@@ -31,7 +31,11 @@ public class WebServicesFraction extends Webservices<WebServicesFraction> implem
     }
 
     public static WebServicesFraction createDefaultFraction() {
-        return new WebServicesFraction().wsdlHost(SOAP_HOST)
+        
+        String SoapHost = System.getProperty("jboss.bind.address", SOAP_HOST);
+        
+        return new WebServicesFraction()
+                .wsdlHost(SoapHost)
                 .endpointConfig(new EndpointConfig(STANDARD_ENDPOINT_CONFIG))
                 .endpointConfig(createRemoteEndpoint())
                 .clientConfig(new ClientConfig(STANDARD_CLIENT_CONFIG));


### PR DESCRIPTION
Support for rewriting the soap:address URL in the published wsdl to the value of jboss.bind.address (or 127.0.0.1 if jboss.bind.address is not set).

This corresponds to the default configuration in Wildfly webservices subsystem.
