### PR TITLE
Fix artifact manager npe

### DIFF
--- a/container/api/src/main/java/org/wildfly/swarm/ArtifactManager.java
+++ b/container/api/src/main/java/org/wildfly/swarm/ArtifactManager.java
@@ -60,6 +60,9 @@ public class ArtifactManager {
 
     public JavaArchive artifact(String gav) throws IOException, ModuleLoadException {
         File file = findFile(gav);
+        if (file == null) {
+            throw new RuntimeException("Artifact not found.");
+        }
         JavaArchive archive = ShrinkWrap.create(JavaArchive.class, file.getName());
         new ZipImporterImpl(archive).importFrom(file);
         return archive;
@@ -156,7 +159,7 @@ public class ArtifactManager {
             classifier = parts[4];
         }
 
-        if (version.isEmpty() || version.equals("*")) {
+        if (version != null && (version.isEmpty() || version.equals("*"))) {
             version = null;
         }
 

--- a/container/api/src/test/java/org/wildfly/swarm/ArtifactManagerTest.java
+++ b/container/api/src/test/java/org/wildfly/swarm/ArtifactManagerTest.java
@@ -1,5 +1,9 @@
 package org.wildfly.swarm;
 
+import static org.junit.Assert.fail;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.wildfly.swarm.bootstrap.util.MavenArtifactDescriptor;
 import org.wildfly.swarm.bootstrap.util.WildFlySwarmDependenciesConf;
@@ -11,23 +15,107 @@ import static org.fest.assertions.Assertions.assertThat;
  */
 public class ArtifactManagerTest {
 
-    @Test
-    public void testDetermineVersion() throws Exception {
+    private static WildFlySwarmDependenciesConf conf = new WildFlySwarmDependenciesConf();
+    private static String ARTIFACT_GROUP_ID="org.jboss.spec.javax.servlet";
+    private static String ARTIFACT_ARTIFACT_ID="jboss-servlet-api_3.1_spec";
+    private static String ARTIFACT_PACKAGING="jar";
+    private static String ARTIFACT_VERSION="1.0.0.Final";
+    private static String ARTIFACT_NAME="jboss-servlet-api_3.1_spec-1.0.0.Final.jar";
+    private static String ARTIFACT_INVALID_GROUP_ID="no.such";
+    private static String ARTIFACT_INVALID_ARTIFACT_ID="thingy";
+    private static String ARTIFACT_INVALID_PACKAGING="jar";
+    private static String ARTIFACT_INVALID_VERSION="1.0.0";
 
-        WildFlySwarmDependenciesConf conf = new WildFlySwarmDependenciesConf();
+    private ArtifactManager manager;
+
+    @BeforeClass
+    public static void setUpClass() throws Exception {
 
         conf.addPrimaryDependency(MavenArtifactDescriptor.fromMscGav("org.jboss.spec.javax.enterprise.concurrent:jboss-concurrency-api_1.0_spec:1.0.0.Final"));
         conf.addPrimaryDependency(MavenArtifactDescriptor.fromMscGav("org.jboss.spec.javax.servlet:jboss-servlet-api_3.1_spec:1.0.0.Final"));
         conf.addExtraDependency(MavenArtifactDescriptor.fromMavenGav("org.jolokia:jolokia-war:war:1.3.2"));
+    }
 
-        ArtifactManager manager = new ArtifactManager(conf);
+    @Before
+    public void setUp() {
+
+        manager = new ArtifactManager(conf);
+    }
+
+    @Test
+    public void testDetermineVersion() throws Exception {
 
         assertThat(manager.determineVersionViaDependenciesConf("org.jboss.spec.javax.enterprise.concurrent", "jboss-concurrency-api_1.0_spec", "jar", null))
                 .isEqualTo("1.0.0.Final");
         assertThat(manager.determineVersionViaDependenciesConf("org.jolokia", "jolokia-war", "war", null))
                 .isEqualTo("1.3.2");
-        assertThat(manager.determineVersionViaDependenciesConf( "no.such", "thingy", "jar", null ) )
+        assertThat(manager.determineVersionViaDependenciesConf(ARTIFACT_INVALID_GROUP_ID, ARTIFACT_INVALID_ARTIFACT_ID, ARTIFACT_INVALID_PACKAGING, null ) )
                 .isNull();
 
     }
+
+    @Test
+    public void testArtifactGroupArtifact() throws Exception {
+
+        assertThat(manager.artifact(String.format("%s:%s", ARTIFACT_GROUP_ID, ARTIFACT_ARTIFACT_ID)).getName())
+        .isEqualTo(ARTIFACT_NAME);
+    }
+
+    @Test
+    public void testArtifactGroupArtifactExplicitName() throws Exception {
+
+        String name = "myname";
+
+        assertThat(manager.artifact(String.format("%s:%s", ARTIFACT_GROUP_ID, ARTIFACT_ARTIFACT_ID), name).getName())
+        .isEqualTo(name);
+    }
+
+    @Test
+    public void testArtifactGroupArtifactVersion() throws Exception {
+
+        assertThat(manager.artifact(String.format("%s:%s:%s", ARTIFACT_GROUP_ID, ARTIFACT_ARTIFACT_ID, ARTIFACT_VERSION)).getName())
+        .isEqualTo(ARTIFACT_NAME);
+    }
+
+    @Test
+    public void testArtifactGroupArtifactPackagingVersion() throws Exception {
+
+        assertThat(manager.artifact(String.format("%s:%s:%s:%s", ARTIFACT_GROUP_ID, ARTIFACT_ARTIFACT_ID, ARTIFACT_PACKAGING, ARTIFACT_VERSION))
+                .getName()).isEqualTo(ARTIFACT_NAME);
+    }
+
+    @Test
+    public void testArtifactInvalidGroupArtifact() throws Exception {
+
+        try {
+            manager.artifact(String.format("%s:%s", ARTIFACT_INVALID_GROUP_ID, ARTIFACT_INVALID_ARTIFACT_ID));
+            fail("RuntimeException should have been thrown");
+        } catch (RuntimeException e) {
+            assertThat(e).hasMessage("Unable to determine version number from 2-part GAV.  Try three!");
+        }
+    }
+
+    @Test
+    public void testArtifactInvalidGroupArtifactVersion() throws Exception {
+
+        try {
+            manager.artifact(String.format("%s:%s:%s", ARTIFACT_INVALID_GROUP_ID, ARTIFACT_INVALID_ARTIFACT_ID, ARTIFACT_INVALID_VERSION));
+            fail("RuntimeException should have been thrown");
+        } catch (RuntimeException e) {
+            assertThat(e).hasMessage("Artifact not found.");
+        }
+    }
+
+    @Test
+    public void testArtifactInvalidGroupArtifactPackagingVersion() throws Exception {
+
+        try {
+            manager.artifact(String.format("%s:%s:%s:%s", ARTIFACT_INVALID_GROUP_ID, ARTIFACT_INVALID_ARTIFACT_ID, ARTIFACT_INVALID_PACKAGING,
+                    ARTIFACT_INVALID_VERSION));
+            fail("RuntimeException should have been thrown");
+        } catch (RuntimeException e) {
+            assertThat(e).hasMessage("Artifact not found.");
+        }
+    }
+
 }


### PR DESCRIPTION
Not sure how this comports with development standards and preferences.  The tests are more complex than before in an attempt to reduce duplication of string literals.  One could make the case it is over-engineering.

I do think this was a genuine bug.
