### PR TITLE
Repeatable http-method

### DIFF
--- a/keycloak/api/src/main/java/org/wildfly/swarm/keycloak/SecuredWebXmlAsset.java
+++ b/keycloak/api/src/main/java/org/wildfly/swarm/keycloak/SecuredWebXmlAsset.java
@@ -75,8 +75,8 @@ public class SecuredWebXmlAsset implements NamedAsset {
 
                 XmlWriter.Element webResourceCollection = securityConstraint.element("web-resource-collection");
                 webResourceCollection.element("url-pattern").content(each.urlPattern()).end();
-                if (each.method() != null) {
-                    webResourceCollection.element("http-method").content(each.method()).end();
+                for (String eachMethod: each.methods()) {
+                    webResourceCollection.element("http-method").content(eachMethod).end();
                 }
                 webResourceCollection.end();
 

--- a/keycloak/api/src/main/java/org/wildfly/swarm/keycloak/SecurityConstraint.java
+++ b/keycloak/api/src/main/java/org/wildfly/swarm/keycloak/SecurityConstraint.java
@@ -24,7 +24,7 @@ import java.util.List;
 public class SecurityConstraint {
 
     private final String urlPattern;
-    private String method;
+    private List<String> methods = new ArrayList<>();
     private List<String> roles = new ArrayList<>();
 
     public SecurityConstraint() {
@@ -40,12 +40,12 @@ public class SecurityConstraint {
     }
 
     public SecurityConstraint withMethod(String method) {
-        this.method = method;
+        this.methods.add(method);
         return this;
     }
 
-    public String method() {
-        return this.method;
+    public List<String> methods() {
+        return this.methods;
     }
 
     public SecurityConstraint withRole(String role) {


### PR DESCRIPTION
Since `http-method` in web.xml is repeatable, it's handy you can chain `withMethod()`.

For now, repeatable `withMethod()` call  override http-method.

``` java
deployment.as(Secured.class)
  .protect()
    .withMethod("POST")
    .withMethod("PUT")
    .withMethod("DELETE")
    .withRole("admin");
```

generated web.xml is:

``` xml
....
<security-constraint>
  <web-resource-collection>
    <url-pattern>/*</url-pattern>
    <http-method>DELETE</http-method>
  </web-resource-collection>
  <auth-constraint>
    <role-name>admin</role-name>
  </auth-constraint>
</security-constraint>
...
```
