### PR TITLE
Add SecurityConstraint overload methods taking varargs

### DIFF
--- a/keycloak/api/src/main/java/org/wildfly/swarm/keycloak/SecuredWebXmlAsset.java
+++ b/keycloak/api/src/main/java/org/wildfly/swarm/keycloak/SecuredWebXmlAsset.java
@@ -80,13 +80,12 @@ public class SecuredWebXmlAsset implements NamedAsset {
                 }
                 webResourceCollection.end();
 
+                XmlWriter.Element authConstraint = securityConstraint.element("auth-constraint");
                 for (String eachRole : each.roles()) {
-                    XmlWriter.Element authConstraint = securityConstraint.element("auth-constraint");
                     authConstraint.element("role-name").content(eachRole).end();
-                    authConstraint.end();
-
                     allRoles.add(eachRole);
                 }
+                authConstraint.end();
 
                 securityConstraint.end();
             }

--- a/keycloak/api/src/main/java/org/wildfly/swarm/keycloak/SecurityConstraint.java
+++ b/keycloak/api/src/main/java/org/wildfly/swarm/keycloak/SecurityConstraint.java
@@ -16,6 +16,7 @@
 package org.wildfly.swarm.keycloak;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -44,12 +45,22 @@ public class SecurityConstraint {
         return this;
     }
 
+    public SecurityConstraint withMethod(String... methods) {
+        this.methods.addAll(Arrays.asList(methods));
+        return this;
+    }
+
     public List<String> methods() {
         return this.methods;
     }
 
     public SecurityConstraint withRole(String role) {
         this.roles.add( role );
+        return this;
+    }
+
+    public SecurityConstraint withRole(String... roles) {
+        this.roles.addAll(Arrays.asList(roles));
         return this;
     }
 


### PR DESCRIPTION
This Pull Request enables you to write a handy code for Secured.

Since `<role-name>` in `<auth-constraint>` should be repeatable, I changed [adding role code](https://github.com/wildfly-swarm/wildfly-swarm/compare/master...emag:add-security-constraint-overload-methods-taking-varargs?expand=1#diff-8580f6769bb572b08ddee24dc7c6ab53R83).

``` java
deployment.as(Secured.class)
  .protect("/entries/*")
    .withMethod("POST", "PUT", "DELETE")
    .withRole("admin", "guest");
```

generated web.xml

``` xml
<web-app ...>

  <context-param>
    <param-name>resteasy.scan</param-name>
    <param-value>true</param-value>
  </context-param>

  <security-constraint>
    <web-resource-collection>
      <url-pattern>/entries/*</url-pattern>
      <http-method>POST</http-method>
      <http-method>PUT</http-method>
      <http-method>DELETE</http-method>
    </web-resource-collection>

    <auth-constraint>
      <role-name>admin</role-name>
      <role-name>guest</role-name>
    </auth-constraint>
  </security-constraint>

  <login-config>
    <auth-method>KEYCLOAK</auth-method>
    <realm-name>ignored</realm-name>
  </login-config>

  <security-role>
    <role-name>admin</role-name>
  </security-role>
  <security-role>
    <role-name>guest</role-name>
  </security-role>

</web-app>
```
