### PR TITLE
adds support for authenticated repos in plugin

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -113,6 +113,10 @@
         <artifactId>plexus-utils</artifactId>
         <version>3.0.21</version>
       </dependency>
+      <dependency>
+        <groupId>org.eclipse.aether</groupId>
+        <artifactId>aether-util</artifactId>
+      </dependency>
     </dependencies>
 
 </project>

--- a/plugin/src/main/java/org/wildfly/swarm/plugin/maven/MavenArtifactResolvingHelper.java
+++ b/plugin/src/main/java/org/wildfly/swarm/plugin/maven/MavenArtifactResolvingHelper.java
@@ -16,6 +16,7 @@
 package org.wildfly.swarm.plugin.maven;
 
 import org.apache.maven.artifact.repository.ArtifactRepository;
+import org.apache.maven.artifact.repository.Authentication;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.impl.ArtifactResolver;
@@ -23,6 +24,7 @@ import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.resolution.ArtifactRequest;
 import org.eclipse.aether.resolution.ArtifactResolutionException;
 import org.eclipse.aether.resolution.ArtifactResult;
+import org.eclipse.aether.util.repository.AuthenticationBuilder;
 import org.wildfly.swarm.tools.ArtifactResolvingHelper;
 import org.wildfly.swarm.tools.ArtifactSpec;
 
@@ -48,6 +50,12 @@ public class MavenArtifactResolvingHelper implements ArtifactResolvingHelper {
 
     public void remoteRepository(ArtifactRepository repo) {
         RemoteRepository.Builder builder = new RemoteRepository.Builder(repo.getId(), "default", repo.getUrl());
+        final Authentication mavenAuth = repo.getAuthentication();
+        if (mavenAuth != null && mavenAuth.getUsername() != null && mavenAuth.getPassword() != null) {
+            builder.setAuthentication(new AuthenticationBuilder()
+                    .addUsername(mavenAuth.getUsername())
+                    .addPassword(mavenAuth.getPassword()).build());
+        }
         this.remoteRepositories.add(builder.build());
     }
 


### PR DESCRIPTION
I could not get the Wildfly plugin to work with my company's Nexus repository / settings.xml. I traced the problem to the plugin failing to authenticate against my repo using credentials.

The compile scope POM dependency seems unnecessary/unfortunate, but without it I would run into an error running the plugin which seems maybe similar to the [error reported here](https://issues.apache.org/jira/browse/MNG-5787). Upgrading Maven did not fix my problem. I am not terribly familiar with using managed dependencies but suspect it may be masking some dependency issue or a problem with plexus classwords a commenter on the Maven issue suggests.

```
[ERROR] Failed to execute goal org.wildfly.swarm:wildfly-swarm-plugin:1.0.0.Alpha6-SNAPSHOT:package (default) on project wildfly-swarm-example-docker-jaxrs-app: Execution default of goal org.wildfly.swarm:wildfly-swarm-plugin:1.0.0.Alpha6-SNAPSHOT:package failed: A required class was missing while executing org.wildfly.swarm:wildfly-swarm-plugin:1.0.0.Alpha6-SNAPSHOT:package: org/eclipse/aether/util/repository/AuthenticationBuilder
[ERROR] -----------------------------------------------------
[ERROR] realm =    plugin>org.wildfly.swarm:wildfly-swarm-plugin:1.0.0.Alpha6-SNAPSHOT
[ERROR] strategy = org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy
[ERROR] urls[0] = file:/Users/jhovell/.m2/repository/org/wildfly/swarm/wildfly-swarm-plugin/1.0.0.Alpha6-SNAPSHOT/wildfly-swarm-plugin-1.0.0.Alpha6-SNAPSHOT.jar
[ERROR] urls[1] = file:/Users/jhovell/.m2/repository/org/wildfly/swarm/wildfly-swarm-tools/1.0.0.Alpha6-SNAPSHOT/wildfly-swarm-tools-1.0.0.Alpha6-SNAPSHOT.jar
[ERROR] urls[2] = file:/Users/jhovell/.m2/repository/org/wildfly/swarm/wildfly-swarm-bootstrap/1.0.0.Alpha6-SNAPSHOT/wildfly-swarm-bootstrap-1.0.0.Alpha6-SNAPSHOT.jar
[ERROR] urls[3] = file:/Users/jhovell/.m2/repository/org/jboss/spec/javax/sql/jboss-javax-sql-api_7.0_spec/2.0.0.Final/jboss-javax-sql-api_7.0_spec-2.0.0.Final.jar
[ERROR] urls[4] = file:/Users/jhovell/.m2/repository/org/jboss/shrinkwrap/shrinkwrap-api/1.1.2/shrinkwrap-api-1.1.2.jar
[ERROR] urls[5] = file:/Users/jhovell/.m2/repository/org/jboss/shrinkwrap/shrinkwrap-spi/1.1.2/shrinkwrap-spi-1.1.2.jar
[ERROR] urls[6] = file:/Users/jhovell/.m2/repository/org/jboss/shrinkwrap/shrinkwrap-impl-base/1.1.2/shrinkwrap-impl-base-1.1.2.jar
[ERROR] urls[7] = file:/Users/jhovell/.m2/repository/org/jboss/shrinkwrap/descriptors/shrinkwrap-descriptors-api-jboss/2.0.0-alpha-8/shrinkwrap-descriptors-api-jboss-2.0.0-alpha-8.jar
[ERROR] urls[8] = file:/Users/jhovell/.m2/repository/org/jboss/shrinkwrap/descriptors/shrinkwrap-descriptors-api-javaee/2.0.0-alpha-7/shrinkwrap-descriptors-api-javaee-2.0.0-alpha-7.jar
[ERROR] urls[9] = file:/Users/jhovell/.m2/repository/org/jboss/shrinkwrap/descriptors/shrinkwrap-descriptors-api-base/2.0.0-alpha-7/shrinkwrap-descriptors-api-base-2.0.0-alpha-7.jar
[ERROR] urls[10] = file:/Users/jhovell/.m2/repository/org/jboss/shrinkwrap/descriptors/shrinkwrap-descriptors-impl-jboss/2.0.0-alpha-8/shrinkwrap-descriptors-impl-jboss-2.0.0-alpha-8.jar
[ERROR] urls[11] = file:/Users/jhovell/.m2/repository/org/jboss/shrinkwrap/descriptors/shrinkwrap-descriptors-impl-javaee/2.0.0-alpha-7/shrinkwrap-descriptors-impl-javaee-2.0.0-alpha-7.jar
[ERROR] urls[12] = file:/Users/jhovell/.m2/repository/org/jboss/shrinkwrap/descriptors/shrinkwrap-descriptors-impl-base/2.0.0-alpha-7/shrinkwrap-descriptors-impl-base-2.0.0-alpha-7.jar
[ERROR] urls[13] = file:/Users/jhovell/.m2/repository/org/jboss/shrinkwrap/descriptors/shrinkwrap-descriptors-spi/2.0.0-alpha-7/shrinkwrap-descriptors-spi-2.0.0-alpha-7.jar
[ERROR] urls[14] = file:/Users/jhovell/.m2/repository/org/ow2/asm/asm-all/5.0.4/asm-all-5.0.4.jar
[ERROR] urls[15] = file:/Users/jhovell/.m2/repository/commons-io/commons-io/2.4/commons-io-2.4.jar
[ERROR] urls[16] = file:/Users/jhovell/.m2/repository/org/codehaus/plexus/plexus-utils/1.1/plexus-utils-1.1.jar
[ERROR] Number of foreign imports: 1
[ERROR] import: Entry[import  from realm ClassRealm[maven.api, parent: null]]
[ERROR] 
[ERROR] -----------------------------------------------------: org.eclipse.aether.util.repository.AuthenticationBuilder
[ERROR] -> [Help 1]
```

I tried this using both Maven 3.3.3 and again after upgrading to the latest, 3.3.9, but had the same error either way.

```
Apache Maven 3.3.9 (bb52d8502b132ec0a5a3f4c09453c07478323dc5; 2015-11-10T08:41:47-08:00)
Maven home: /usr/local/Cellar/maven/3.3.9
Java version: 1.8.0_51, vendor: Oracle Corporation
Java home: /Library/Java/JavaVirtualMachines/jdk1.8.0_51.jdk/Contents/Home/jre
Default locale: en_US, platform encoding: UTF-8
OS name: "mac os x", version: "10.11.1", arch: "x86_64", family: "mac"
```

I also noticed the plugin module does not have any testing. I would be happy to add some basic JUnit testing or some other testing but wanted to get feedback first as maybe I don't understand 
