### PR TITLE
adds module dependencies needed when using ribbon.IsSecure (SSL)

### DIFF
--- a/ribbon/modules/src/main/resources/modules/com/netflix/ribbon/main/module.xml
+++ b/ribbon/modules/src/main/resources/modules/com/netflix/ribbon/main/module.xml
@@ -19,6 +19,7 @@
     <module name="com.google.guava" slot="netflix"/>
     <module name="javax.api"/>
     <module name="org.wildfly.swarm.netflix.ribbon" slot="runtime"/>
+    <module name="org.apache.commons.lang"/>
   </dependencies>
 
 </module>

--- a/rxnetty/src/main/resources/modules/io/reactivex/rxnetty/main/module.xml
+++ b/rxnetty/src/main/resources/modules/io/reactivex/rxnetty/main/module.xml
@@ -10,6 +10,7 @@
     <module name="io.netty"/>
     <module name="com.netflix.servo"/>
     <module name="org.slf4j"/>
+    <module name="javax.api"/>
   </dependencies>
 
 </module>


### PR DESCRIPTION
@bobmcwhirter Is there typically a way to test this?

I am guessing this is a shortcoming of the way Netflix libraries such as ribbon state many dependencies as "runtime". org.apache.commons.lang (not lang3) is a runtime dependency of ribbon-core, and as a result unless it is explicitly stated as a module dependency, we get a NoClassDefFoundError at runtime.

For Rxnetty, if using SSL, it uses javax.net.ssl. which requires the dependency on javax.api module.

I could add to the examples repo if you think it is useful to demonstrate Ribbon using SSL with self-signed certificates.
