### PR TITLE
Allows user to configure maximum Ribbon payload size

### DIFF
--- a/ribbon-secured/client/src/main/java/org/wildfly/swarm/netflix/ribbon/secured/client/SecuredRibbon.java
+++ b/ribbon-secured/client/src/main/java/org/wildfly/swarm/netflix/ribbon/secured/client/SecuredRibbon.java
@@ -19,7 +19,11 @@ package org.wildfly.swarm.netflix.ribbon.secured.client;
  * @author Bob McWhirter
  */
 public class SecuredRibbon {
-    public static <T> T from(Class<T> classType) {
+    public static <T> T from(final Class<T> classType) {
         return SecuredRibbonResourceFactory.INSTANCE.from(classType);
     }
+    
+    public static <T> T from(final SecuredRibbonResourceFactory factory, final Class<T> classType) {
+        return factory.from(classType);
+    } 
 }

--- a/ribbon-secured/client/src/main/java/org/wildfly/swarm/netflix/ribbon/secured/client/SecuredRibbonResourceFactory.java
+++ b/ribbon-secured/client/src/main/java/org/wildfly/swarm/netflix/ribbon/secured/client/SecuredRibbonResourceFactory.java
@@ -20,17 +20,22 @@ import com.netflix.ribbon.RibbonResourceFactory;
 import com.netflix.ribbon.RibbonTransportFactory;
 import com.netflix.ribbon.proxy.processor.AnnotationProcessorsProvider;
 
+import io.reactivex.netty.protocol.http.HttpObjectAggregationConfigurator;
+
 /**
  * @author Bob McWhirter
  */
 public class SecuredRibbonResourceFactory extends RibbonResourceFactory {
 
-    public static SecuredRibbonResourceFactory INSTANCE = new SecuredRibbonResourceFactory(
-            ClientConfigFactory.DEFAULT,
-            new SecuredTransportFactory(),
-            AnnotationProcessorsProvider.DEFAULT);
+    public static SecuredRibbonResourceFactory INSTANCE = new SecuredRibbonResourceFactory(HttpObjectAggregationConfigurator.DEFAULT_CHUNK_SIZE);
 
-    public SecuredRibbonResourceFactory(ClientConfigFactory configFactory, RibbonTransportFactory transportFactory, AnnotationProcessorsProvider processors) {
+    public SecuredRibbonResourceFactory(final int maxChunkSize) {
+        this(ClientConfigFactory.DEFAULT,
+            new SecuredTransportFactory(maxChunkSize),
+            AnnotationProcessorsProvider.DEFAULT);
+    }
+    
+    public SecuredRibbonResourceFactory(final ClientConfigFactory configFactory, final RibbonTransportFactory transportFactory, final AnnotationProcessorsProvider processors) {
         super(configFactory, transportFactory, processors);
     }
 


### PR DESCRIPTION
@bobmcwhirter 

So far the only default configuration with Ribbon that I think is "unreasonable" is the HttpObjectAggregationConfigurator.DEFAULT_CHUNK_SIZE (1MB). Basically if you have a REST payload that exceeds 1MB Ribbon fails. You need to configure Ribbon for the maximum message size you want ionetty to be capable of dealing with

https://groups.google.com/forum/#!topic/ribbon-users/nviL9gcIows

I have expanded the secured ribbon client api slightly to allow users to pass in their own SecuredRibbonResourceFactory which can be constructed via a simplified public constructor. Maybe an options object or more generally options belong here, but I guess it is a start.

You can now use RibbonSecured with a custom chunk size in a variety of ways :

``` java
// I want 4MB messages
final SecuredRibbonResourceFactory ribbonResourceFactory = new SecuredRibbonResourceFactory(HttpObjectAggregationConfigurator.DEFAULT_CHUNK_SIZE * 4);
// use proxies
final MyService service = SecuredRibbon.from(ribbonResourceFactory, MyService.class);
// work with resource groups directly
final HttpResourceGroup resourceGroup = ribbonResourceFactory.createHttpResourceGroup("MyOtherService");

```
