### PR TITLE
fixes keycloak after c919fea5e829e0979ed06d2930afdd1eed7e4266

### DIFF
--- a/keycloak/modules/src/main/resources/modules/org/wildfly/swarm/keycloak/api/module.xml
+++ b/keycloak/modules/src/main/resources/modules/org/wildfly/swarm/keycloak/api/module.xml
@@ -4,6 +4,7 @@
   </resources>
 
   <dependencies>
+    <module name="org.wildfly.swarm.undertow"/>
     <module name="org.wildfly.swarm.container"/>
     <module name="org.wildfly.swarm.configuration"/>
     <module name="org.jboss.shrinkwrap"/>


### PR DESCRIPTION
@kenfinnigan @bobmcwhirter 

Seems this might now be required?

This should address the following bug:

https://issues.jboss.org/browse/SWARM-298
